### PR TITLE
Fixed internal init(wrappedValue:) error

### DIFF
--- a/CodableProperty/Classes/CodableProperty.swift
+++ b/CodableProperty/Classes/CodableProperty.swift
@@ -24,6 +24,10 @@ import Foundation
 @propertyWrapper public struct EncodableProperty<Transformer: EncodableTransformer>: Encodable {
     public var wrappedValue: Transformer.Value
     
+    public init(wrappedValue: Transformer.Value) {
+        self.wrappedValue = wrappedValue
+    }
+    
     public func encode(to encoder: Encoder) throws {
         try Transformer.encode(value: wrappedValue, to: encoder)
     }


### PR DESCRIPTION
Fixed compiler error in Xcode 11 beta 5 about internal init(wrappedValue:)